### PR TITLE
fix depth output for water level hazard

### DIFF
--- a/src/fiat/method/flood/level.py
+++ b/src/fiat/method/flood/level.py
@@ -4,13 +4,16 @@ import math
 
 from fiat.method.flood.depth import fn_impact
 from fiat.method.util import ZONAL_METHODS
-from fiat.util import FLOOD_LEVEL, LEVEL
+from fiat.util import DEPTH, FLOOD_LEVEL, LEVEL
 
 __all__ = ["fn_impact"]
 
 COLUMNS = ["reference", "elevation"]
 NAME = FLOOD_LEVEL
-NEW_COLUMNS = [LEVEL]
+# The stored value is a depth above the floor (water_level - ground_elevation -
+# height_above_ground), the same quantity as the flood.depth method, so report
+# it under the "depth" column rather than "level".
+NEW_COLUMNS = [DEPTH]
 TYPES = [f"water_{LEVEL}"]
 
 


### PR DESCRIPTION
The flood.level method stores a depth above the ground floor (water_level - ground_elevation - height_above_ground), the same quantity the flood.depth method produces. It was written under a "level_*" column, which is misleading

## Issue addressed
Fixes #<issue number>

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
